### PR TITLE
Refactored UA-Clarity-Tools.

### DIFF
--- a/ua_clarity_tools/tests/test_ua_clarity_tools.py
+++ b/ua_clarity_tools/tests/test_ua_clarity_tools.py
@@ -11,7 +11,6 @@ from jinja2 import Template
 from bs4 import BeautifulSoup
 from ua_clarity_tools import ua_clarity_tools
 from ua_clarity_tools import api_types
-import pdb
 
 
 CLARITY_TOOLS = None
@@ -328,7 +327,11 @@ class TestStepTools(unittest.TestCase):
         in_out_uris = self._harvest_art_uris("map")
 
         all_uris = list(in_out_uris.keys())
-        all_uris.extend(list(in_out_uris.values()))
+        for value in in_out_uris.values():
+            if type(value) == list:
+                all_uris.extend(value)
+            else:
+                all_uris.append(value)
 
         arts_soup = BeautifulSoup(self.step_tools.api.get(all_uris), "xml")
 
@@ -365,8 +368,6 @@ class TestStepTools(unittest.TestCase):
 
             assert out_arts[0].location == expected_output.find(
                 "location").find("value").text
-
-        assert True
 
     def test_get_artifact_map_uri_only_one_input_one_output(self):
         test_map = self.step_tools.get_artifact_map(uri_only=True)

--- a/ua_clarity_tools/tests/test_ua_clarity_tools.py
+++ b/ua_clarity_tools/tests/test_ua_clarity_tools.py
@@ -337,21 +337,32 @@ class TestStepTools(unittest.TestCase):
                 attrs={"uri": re.compile(f"{in_art.uri}.*")})
             expected_output = arts_soup.find(
                 attrs={"uri": re.compile(f"{out_arts[0].uri}.*")})
-            pdb.set_trace()
 
             assert in_out_uris[
                 in_art.uri] == expected_output["uri"].split('?')[0]
 
             assert in_art.name == expected_input.find("name").text
-            assert in_art.container_uri == expected_input.find(
-                "container")["uri"]
+            input_con_uri = expected_input.find("container")["uri"]
+            assert in_art.container_uri == input_con_uri
+
+            input_con_soup = BeautifulSoup(
+                self.step_tools.api.get(input_con_uri), "xml")
+            assert in_art.container_name == input_con_soup.find("name").text
+            assert in_art.container_type == input_con_soup.find("type")["name"]
 
             assert in_art.location == expected_input.find(
                 "location").find("value").text
 
             assert out_arts[0].name == expected_output.find("name").text
-            assert out_arts[0].container_uri == expected_output.find(
-                "container")["uri"]
+            output_con_uri = expected_output.find("container")["uri"]
+            assert out_arts[0].container_uri == output_con_uri
+            output_con_soup = BeautifulSoup(
+                self.step_tools.api.get(output_con_uri), "xml")
+            assert out_arts[0].container_name == output_con_soup.find(
+                "name").text
+            assert out_arts[0].container_type == output_con_soup.find(
+                "type")["name"]
+
             assert out_arts[0].location == expected_output.find(
                 "location").find("value").text
 

--- a/ua_clarity_tools/tests/test_ua_clarity_tools.py
+++ b/ua_clarity_tools/tests/test_ua_clarity_tools.py
@@ -11,6 +11,7 @@ from jinja2 import Template
 from bs4 import BeautifulSoup
 from ua_clarity_tools import ua_clarity_tools
 from ua_clarity_tools import api_types
+import pdb
 
 
 CLARITY_TOOLS = None
@@ -321,6 +322,40 @@ class TestStepTools(unittest.TestCase):
                 "container")["uri"]
             assert out_arts[0].location == expected_output.find(
                 "location").find("value").text
+
+    def test_get_artifact_map_container_info_one_input_one_output(self):
+        test_map = self.step_tools.get_artifact_map(container_info=True)
+        in_out_uris = self._harvest_art_uris("map")
+
+        all_uris = list(in_out_uris.keys())
+        all_uris.extend(list(in_out_uris.values()))
+
+        arts_soup = BeautifulSoup(self.step_tools.api.get(all_uris), "xml")
+
+        for in_art, out_arts in test_map.items():
+            expected_input = arts_soup.find(
+                attrs={"uri": re.compile(f"{in_art.uri}.*")})
+            expected_output = arts_soup.find(
+                attrs={"uri": re.compile(f"{out_arts[0].uri}.*")})
+            pdb.set_trace()
+
+            assert in_out_uris[
+                in_art.uri] == expected_output["uri"].split('?')[0]
+
+            assert in_art.name == expected_input.find("name").text
+            assert in_art.container_uri == expected_input.find(
+                "container")["uri"]
+
+            assert in_art.location == expected_input.find(
+                "location").find("value").text
+
+            assert out_arts[0].name == expected_output.find("name").text
+            assert out_arts[0].container_uri == expected_output.find(
+                "container")["uri"]
+            assert out_arts[0].location == expected_output.find(
+                "location").find("value").text
+
+        assert True
 
     def test_get_artifact_map_uri_only_one_input_one_output(self):
         test_map = self.step_tools.get_artifact_map(uri_only=True)

--- a/ua_clarity_tools/ua_clarity_tools.py
+++ b/ua_clarity_tools/ua_clarity_tools.py
@@ -8,10 +8,10 @@ import requests
 from bs4 import BeautifulSoup, Tag
 from jinja2 import Template
 from ua_clarity_api import ua_clarity_api
-import pdb
 
 
-__author__ = ("Stephen Stern, Archer Morgan, Rafael Lopez,",
+__author__ = (
+    "Stephen Stern, Archer Morgan, Rafael Lopez,",
     "Ryan Johannes-Bland, Etienne Thompson")
 __maintainer__ = "Ryan Johannes-Bland"
 __email__ = "rjjohannesbland@email.arizona.edu"

--- a/ua_clarity_tools/ua_clarity_tools.py
+++ b/ua_clarity_tools/ua_clarity_tools.py
@@ -504,12 +504,13 @@ class StepTools():
             artifact_map (dict {input artifact: [output_artifact]}):
                 Returns a dict of input artifact : all output artifacts.
         """
-        # Make a dict with input_uri: input_artifact.
-        input_uri_art = {
-            art.uri: art for art in self.get_artifacts("input")}
-        # Make a dict with output_uri: output_artifact.
-        output_uri_art = {
-            art.uri: art for art in self.get_artifacts("output")}
+        if not uri_only:
+            # Make a dict with input_uri: input_artifact.
+            input_uri_art = {
+                art.uri: art for art in self.get_artifacts("input")}
+            # Make a dict with output_uri: output_artifact.
+            output_uri_art = {
+                art.uri: art for art in self.get_artifacts("output")}
 
         # The container_name and container_type fields will always be None,
         # because it is not always necessary. They exist so that
@@ -561,6 +562,7 @@ class StepTools():
                             output_uri].container_name = output_con_name
                         output_uri_art[
                             output_uri].container_type = output_con_type
+
                     # Convert to hashable namedtuples excluding the UDF map.
                     input_art = Hashable_Artifact(
                         *(astuple(input_uri_art[input_uri])[:-1]))
@@ -569,6 +571,7 @@ class StepTools():
 
                     artifact_map.setdefault(input_art, list())
                     artifact_map[input_art].append(output_art)
+
         return artifact_map
 
     def set_artifact_udf(self, sample_values, stream):
@@ -641,7 +644,7 @@ class StepTools():
         self.api.post(f"{self.api.host}artifacts/batch/update", update_xml)
 
     def get_artifacts_previous_step(
-            self, dest_step, stream, art_smp_uris, step_soup, results=None):
+            self, dest_step, stream, art_smp_uris, step_soup, results=dict()):
         """Return artifact uris mapped to ancestor artifacts from a target
             step.
 
@@ -675,8 +678,6 @@ class StepTools():
                 went through the step separately from its fellows, this
                 will not work.
         """
-        results = results or dict()
-
         try:
             step_name = step_soup.find("configuration").text
         except AttributeError:

--- a/ua_clarity_tools/ua_clarity_tools.py
+++ b/ua_clarity_tools/ua_clarity_tools.py
@@ -8,6 +8,7 @@ import requests
 from bs4 import BeautifulSoup, Tag
 from jinja2 import Template
 from ua_clarity_api import ua_clarity_api
+import pdb
 
 
 __author__ = ("Stephen Stern, Archer Morgan, Rafael Lopez,",
@@ -490,7 +491,7 @@ class StepTools():
 
         return process
 
-    def get_artifact_map(self, uri_only=False):
+    def get_artifact_map(self, uri_only=False, container_info=False):
         """Returns a map of input artifacts to output artifacts, either as uris
             or as Artifact dataclasses. One input artifact can be mapped to a
             list of their multiple output artifacts.
@@ -504,10 +505,10 @@ class StepTools():
                 Returns a dict of input artifact : all output artifacts.
         """
         # Make a dict with input_uri: input_artifact.
-        input_uri_artifact = {
+        input_uri_art = {
             art.uri: art for art in self.get_artifacts("input")}
         # Make a dict with output_uri: output_artifact.
-        output_uri_artifact = {
+        output_uri_art = {
             art.uri: art for art in self.get_artifacts("output")}
 
         # The container_name and container_type fields will always be None,
@@ -533,16 +534,38 @@ class StepTools():
                 input_uri = io_map.find("input")["uri"]
                 output_uri = output_soup["uri"]
 
-                if uri_only:
+                if uri_only and not container_info:
                     artifact_map.setdefault(input_uri, list())
                     artifact_map[input_uri].append(output_uri)
 
                 else:
+                    if container_info:
+                        input_con_soup = BeautifulSoup(
+                            self.api.get(
+                                input_uri_art[input_uri].container_uri),
+                            "xml")
+                        input_con_name = input_con_soup.find("name").text
+                        input_con_type = input_con_soup.find("type")["name"]
+                        input_uri_art[
+                            input_uri].container_name = input_con_name
+                        input_uri_art[
+                            input_uri].container_type = input_con_type
+
+                        output_con_soup = BeautifulSoup(
+                            self.api.get(
+                                output_uri_art[output_uri].container_uri),
+                            "xml")
+                        output_con_name = output_con_soup.find("name").text
+                        output_con_type = output_con_soup.find("type")["name"]
+                        output_uri_art[
+                            output_uri].container_name = output_con_name
+                        output_uri_art[
+                            output_uri].container_type = output_con_type
                     # Convert to hashable namedtuples excluding the UDF map.
                     input_art = Hashable_Artifact(
-                        *(astuple(input_uri_artifact[input_uri])[:-1]))
+                        *(astuple(input_uri_art[input_uri])[:-1]))
                     output_art = Hashable_Artifact(
-                        *(astuple(output_uri_artifact[output_uri])[:-1]))
+                        *(astuple(output_uri_art[output_uri])[:-1]))
 
                     artifact_map.setdefault(input_art, list())
                     artifact_map[input_art].append(output_art)


### PR DESCRIPTION
ua_clarity_tools.py
        - Made it so get_artifacts is only called when uri_only is not set
            to true.
        - Changed results argument to be default dict() when not specified
            rather than None and redundantly set it to dict() if not
            given another value.
    
test_ua_clarity_tools.py
        - Added check to make sure set container information is the same
            as what should've been scraped to the container_info test.