### PR TITLE
allow get_artifacts_previous_step to process samples with different histories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project can be found here.
 The format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### 2022/02/23 [1.1.8](https://github.com/UACoreFacilitiesIT/UA-Clarity-Tools)
+
+Updated the "get_artifacts_previous_step()" method so that it can handle input samples that traveled through the previous step at different times (different process ids). The function will know travel down all the paths in the step history, not just the first path.
+
 ### 2022/11/14 [1.1.7](https://github.com/UACoreFacilitiesIT/UA-Clarity-Tools)
 
 Updated the step router so it won't timeout when routing to steps with many queued samples.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format of this changelog is based on [Keep a Changelog](https://keepachangel
 
 ### 2022/02/23 [1.1.8](https://github.com/UACoreFacilitiesIT/UA-Clarity-Tools)
 
-Updated the "get_artifacts_previous_step()" method so that it can handle input samples that traveled through the previous step at different times (different process ids). The function will know travel down all the paths in the step history, not just the first path.
+Updated the "get_artifacts_previous_step()" method so that it can handle input samples that traveled through the previous step at different times (different process ids). The function will now travel down all the paths in the step history, not just the first path.
 
 ### 2022/11/14 [1.1.7](https://github.com/UACoreFacilitiesIT/UA-Clarity-Tools)
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def readme(filename):
 
 setup(
     name="ua_clarity_tools",
-    version="1.1.7",
+    version="1.1.8",
     packages=find_packages(),
     author="Stephen Stern, Rafael Lopez, Ryan Johannes-Bland",
     author_email="sterns1@email.arizona.edu",


### PR DESCRIPTION
Previously, this method was set to error if samples had gotten through the previous step at different times. This modifies the recursion to follow all paths and return all results, even if they're from different instances of the step.